### PR TITLE
[FIX] retorna NONE en caso de que tenga el campo de no timbrar activado

### DIFF
--- a/qualtop_account/models/account_invoice.py
+++ b/qualtop_account/models/account_invoice.py
@@ -19,6 +19,13 @@ class AccountMove(models.Model):
             return super(AccountMove, self)._l10n_mx_edi_sign()
         res = super(AccountMove, self)._l10n_mx_edi_sign()
         return res
+
+    def l10n_mx_edi_update_sat_status(self):
+        if self.not_sign:
+            return
+        res = super(AccountMove, self).l10n_mx_edi_update_sat_status
+        return res
+
     def button_draft(self):
         if self.not_sign:
             return super(AccountMove, self).button_draft()


### PR DESCRIPTION
Este fix permitirá que no se sobreescriban los valores  del PAC, ni se sobreescriban los valores, como si fueran timbres de prueba.