### PR TITLE
[FIX] ignora el CFDI para complemento de pago, solo sí ..

### DIFF
--- a/qualtop_account/models/account_payment.py
+++ b/qualtop_account/models/account_payment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, _
+from odoo.exceptions import UserError
 
 
 class AccountPayment(models.Model):
@@ -14,3 +15,13 @@ class AccountPayment(models.Model):
             )
             return True
         return super(AccountPayment, self)._l10n_mx_edi_sign()
+
+    def l10n_mx_edi_is_required(self):
+        self.ensure_one()
+        acc_move = self.env['account.move'].search([('name', '=', self.communication), ('state', '!=', 'cancel')])
+        if len(acc_move) > 1:
+            raise UserError('Lo siento, hay dos facturas con el Folio : {}  , favor de contactar con el administrador'.format(self.communication))
+
+        if acc_move.not_sign_complement or acc_move.not_sign:
+            return True
+        return super(AccountPayment, self).l10n_mx_edi_is_required()


### PR DESCRIPTION
Ignora el CFDI requerido en el sistema, siempre y cuando tenga activada la casilla de "No timbrar complemento de pago", "No timbrar" en la factura origen del pago aplicado